### PR TITLE
Gives a proper exception if token is invalid

### DIFF
--- a/abakus/auth.py
+++ b/abakus/auth.py
@@ -15,7 +15,7 @@ HEADERS = {
 path = ''.join(['/api/', settings.ABAKUS_TOKEN, '/user/check/'])
 
 
-class TokenError(Exception):
+class ApiError(Exception):
     def __init__(self, value):
         self.value = value
     def __str__(self):
@@ -35,8 +35,8 @@ class AbakusBackend:
         info = json.load(response)
         try:
             user_info = info['user']
-        except Exception:
-            raise TokenError(info['status_message'])
+        except KeyError:
+            raise ApiError(info['status_message'])
 
         name = ''
         if 'name' in user_info:


### PR DESCRIPTION
Usikker på om dette er ønsket funksjonalitet fra deres side, men det gjør feilsøking litt enklere. Ved ugyldig token fikk man før en `KeyError` med message `'user'`. Nå får man en `TokenError` med den meldingen som sendes fra backenden.
